### PR TITLE
SMP-31 admin can add users to supplier

### DIFF
--- a/app/controllers/spree/admin/suppliers_controller.rb
+++ b/app/controllers/spree/admin/suppliers_controller.rb
@@ -1,7 +1,7 @@
 class Spree::Admin::SuppliersController < Spree::Admin::ResourceController
 
   def update
-    @object.address = Spree::Address.immutable_merge(@object.address, params[:supplier][:address_attributes])
+    @object.address = Spree::Address.immutable_merge(@object.address, permitted_resource_params[:address_attributes])
 
     if @object.update_attributes(permitted_resource_params.except(:address_attributes))
       respond_with(@object) do |format|

--- a/app/controllers/spree/api/v1/stock_locations_controller_decorator.rb
+++ b/app/controllers/spree/api/v1/stock_locations_controller_decorator.rb
@@ -1,4 +1,4 @@
-Spree::Api::V1::StockLocationsController.class_eval do
+Spree::Api::StockLocationsController.class_eval do
 
   before_action :supplier_locations, only: [:index]
   before_action :supplier_transfers, only: [:index]

--- a/app/mailers/spree/drop_ship_order_mailer.rb
+++ b/app/mailers/spree/drop_ship_order_mailer.rb
@@ -1,7 +1,7 @@
 module Spree
   class DropShipOrderMailer < Spree::BaseMailer
 
-    default from: Spree::Store.current.mail_from_address
+    default from: Spree::Store.default.mail_from_address
 
     def supplier_order(shipment_id)
       @shipment = Shipment.find shipment_id

--- a/app/models/spree/supplier.rb
+++ b/app/models/spree/supplier.rb
@@ -1,5 +1,6 @@
 class Spree::Supplier < Spree::Base
   extend FriendlyId
+  # include ActiveModel::ForbiddenAttributesProtection
   friendly_id :name, use: :slugged
 
   attr_accessor :password, :password_confirmation
@@ -14,12 +15,14 @@ class Spree::Supplier < Spree::Base
     has_many :ckeditor_pictures
     has_many :ckeditor_attachment_files
   end
-  has_many   :products, through: :variants
-  has_many   :shipments, through: :stock_locations
-  has_many   :stock_locations
   has_many   :supplier_variants
-  has_many   :users, class_name: Spree.user_class.to_s
   has_many   :variants, through: :supplier_variants
+  has_many   :products, through: :variants
+
+  has_many   :stock_locations
+  has_many   :shipments, through: :stock_locations
+
+  has_many   :users, class_name: Spree.user_class.to_s
 
   #==========================================
   # Validations


### PR DESCRIPTION
updates how params are referenced in admin/suppliers_controller …so admin can properly add a user to a supplier without error

NOTE: also includes some misc updates to fix issues that came up when trying to run 'rails erd' to create an ERD
* these are probably issues we would have come across anyway, but happened to come up now, probably because rails-erd tries to load up all of the models, even those that we might not have touched up till this point

