### PR TITLE
Market maker can associate product with supplier and suppliers only see their own products

### DIFF
--- a/app/assets/javascripts/spree/backend/solidus_marketplace.js
+++ b/app/assets/javascripts/spree/backend/solidus_marketplace.js
@@ -1,2 +1,5 @@
 //= require spree/backend
 // Shipments AJAX API
+
+//= require spree/backend/solidus_marketplace_routes
+//= require spree/backend/suppliers_autocomplete

--- a/app/assets/javascripts/spree/backend/solidus_marketplace_routes.js
+++ b/app/assets/javascripts/spree/backend/solidus_marketplace_routes.js
@@ -1,0 +1,1 @@
+Spree.routes.suppliers_search = Spree.pathFor('api/suppliers')

--- a/app/assets/javascripts/spree/backend/suppliers_autocomplete.js
+++ b/app/assets/javascripts/spree/backend/suppliers_autocomplete.js
@@ -1,0 +1,55 @@
+$.fn.supplierAutocomplete = function () {
+  'use strict';
+
+  this.select2({
+      placeholder: Spree.translations.supplier_placeholder,
+      multiple: true,
+      initSelection: function (element, callback) {
+        var ids = element.val(),
+            count = ids.split(",").length;
+
+        Spree.ajax({
+          type: "GET",
+          url: Spree.routes.suppliers_search,
+          data: {
+            ids: ids,
+            per_page: count
+          },
+          success: function (data) {
+            callback(data['suppliers']);
+          }
+        });
+      },
+      ajax: {
+        url: Spree.routes.suppliers_search,
+        datatype: 'json',
+        data: function (term, page) {
+          return {
+            per_page: 50,
+            page: page,
+            q: {
+              name_cont: term
+            },
+            token: Spree.api_key
+          };
+        },
+        results: function (data, page) {
+          var more = page < data.pages;
+          return {
+            results: data['suppliers'],
+            more: more
+          };
+        }
+      },
+      formatResult: function (supplier, container, query, escapeMarkup) {
+        return escapeMarkup(supplier.name);
+      },
+      formatSelection: function (supplier, container, escapeMarkup) {
+        return escapeMarkup(supplier.name);
+      }
+    });
+};
+
+$(document).ready(function () {
+  $('#product_supplier_ids').supplierAutocomplete();
+});

--- a/app/controllers/spree/admin/products_controller_decorator.rb
+++ b/app/controllers/spree/admin/products_controller_decorator.rb
@@ -1,20 +1,70 @@
 Spree::Admin::ProductsController.class_eval do
 
-  before_action :get_suppliers, only: [:edit, :update]
-  before_action :supplier_collection, only: [:index]
-  create.after :add_product_to_supplier
+  before_action :get_suppliers,            only: [:edit] #, :update]
+  before_action :supplier_collection,      only: [:index]
+  after_action  :update_product_suppliers, only: [:update]
+  create.after  :add_product_to_supplier
 
   private
+
+  def permitted_resource_params
+    params[object_name].present? ? params.require(object_name).permit! : ActionController::Parameters.new.permit!
+    params[object_name].except(:supplier_ids)
+  end
+
+  def update_product_suppliers
+    if adding_suppliers?
+      supplier_ids = new_supplier_ids - current_supplier_ids
+      @product.add_suppliers!(supplier_ids)
+    elsif removing_suppliers?
+      supplier_ids = current_supplier_ids - new_supplier_ids
+      @product.remove_suppliers!(supplier_ids)
+    elsif same_number_of_suppliers? && different_suppliers?
+      @product.remove_suppliers!(current_suppliers)
+      @product.add_suppliers!(new_suppliers)
+    elsif same_suppliers?
+      #noop
+    end
+  end
+
+  def adding_suppliers?
+    new_supplier_ids.count > current_supplier_ids.count
+  end
+
+  def removing_suppliers?
+    new_supplier_ids.count < current_supplier_ids.count
+  end
+
+  def same_suppliers?
+    new_supplier_ids == current_supplier_ids
+  end
+
+  def same_number_of_suppliers?
+    new_supplier_ids.count == current_supplier_ids.count
+  end
+
+  def different_suppliers?
+    new_supplier_ids.sort != current_supplier_ids.sort
+  end
+
+  def new_supplier_ids
+    return [] unless params["product"].present? && params["product"]["supplier_ids"].present?
+    params["product"]["supplier_ids"].split(",").map(&:to_i)
+  end
+
+  def current_supplier_ids
+    @product.supplier_ids
+  end
 
   def get_suppliers
     @suppliers = Spree::Supplier.order(:name)
   end
 
-  # Scopes the collection to the Supplier
-  # Doesn't work with normal hash conditions on the ability, due to the
-  # LEFT OUTER JOIN that occurs from ransack instead of an inner join.
+  # Scopes the collection to what the user should have access to, based on the user's role
   def supplier_collection
-    if try_spree_current_user && !try_spree_current_user.admin? && try_spree_current_user.supplier?
+    return unless try_spree_current_user
+
+    if try_spree_current_user.supplier?
       @collection = @collection.joins(:suppliers).where('spree_suppliers.id = ?', try_spree_current_user.supplier_id)
     end
   end

--- a/app/controllers/spree/api/suppliers_controller.rb
+++ b/app/controllers/spree/api/suppliers_controller.rb
@@ -1,0 +1,16 @@
+module Spree
+  module Api
+    class SuppliersController < Spree::Api::BaseController
+      def index
+        if params[:ids]
+          @suppliers = Spree::Supplier.accessible_by(current_ability, :read).where(id: params[:ids].split(',')).order(:name)
+        else
+          @suppliers = Spree::Supplier.accessible_by(current_ability, :read).order(:name).ransack(params[:q]).result
+        end
+
+        @suppliers = paginate(@suppliers)
+        respond_with(@suppliers)
+      end
+    end
+  end
+end

--- a/app/helpers/spree/api/api_helpers_decorator.rb
+++ b/app/helpers/spree/api/api_helpers_decorator.rb
@@ -1,0 +1,22 @@
+module Spree
+  module Api
+    module ApiHelpers
+
+      @@supplier_attributes = [
+        :id,
+        :address_id,
+        :commission_flat_rate,
+        :commission_percentage,
+        :email,
+        :name,
+        :url,
+        :deleted_at,
+        :tax_id,
+        :token,
+        :slug
+      ]
+
+      mattr_reader(:supplier_attributes)
+    end
+  end
+end

--- a/app/models/spree/stock/splitter/drop_ship.rb
+++ b/app/models/spree/stock/splitter/drop_ship.rb
@@ -8,11 +8,10 @@ module Spree
           split_packages = []
           packages.each do |package|
             # Package fulfilled items together.
-            fulfilled = package.contents.select { |content| 
+            fulfilled = package.contents.select { |content|
               begin
-              content.variant.suppliers.count == 0 
+              content.variant.suppliers.count == 0
               rescue => e
-                binding.pry
               end
             }
             split_packages << build_package(fulfilled)
@@ -24,7 +23,7 @@ module Spree
               # Select suppliers ordering ascending according to cost.
               suppliers = variant.supplier_variants.order("spree_supplier_variants.cost ASC").map(&:supplier)
               # Select first supplier that has stock location with avialable stock item.
-              available_supplier = suppliers.detect do |supplier| 
+              available_supplier = suppliers.detect do |supplier|
                 supplier.stock_locations_with_available_stock_items(variant).any?
               end
               # Select the first available stock location with in the available_supplier stock locations.
@@ -38,7 +37,6 @@ module Spree
             end
           end
           rescue => e
-            binding.pry
           end
           return_next split_packages
         end

--- a/app/models/spree/stock_location_decorator.rb
+++ b/app/models/spree/stock_location_decorator.rb
@@ -11,6 +11,11 @@ Spree::StockLocation.class_eval do
     end
   end
 
+  def unpropagate_variant(variant)
+    stock_items = self.stock_items.where(variant: variant)
+    stock_items.map(&:destroy)
+  end
+
   def available?(variant)
     stock_item(variant).try(:available?)
   end

--- a/app/models/spree/supplier_ability.rb
+++ b/app/models/spree/supplier_ability.rb
@@ -5,24 +5,23 @@ module Spree
     def initialize(user)
       user ||= Spree.user_class.new
 
-      if user.supplier
-        # Does not work inline due to ransack applied on collections in admin controller
-        # can [:admin, :stock, :manage, :index], Spree::Product, suppliers: { id: user.supplier_id }
-        can [:admin, :read, :stock], Spree::Product, supplier_ids: user.supplier_id
-        can [:manage], Spree::Product do |product|
-          product.supplier_ids.include?(user.supplier_id)
-        end
-        # can [:admin, :create, :index], Spree::Product
-        can [:admin, :read], Spree::Variant
-        can [:admin, :manage, :read, :ready, :ship], Spree::Shipment, order: { state: 'complete' }, stock_location: { supplier_id: user.supplier_id }
-        can [:admin, :create, :update], :stock_items
-        can [:admin, :manage], Spree::StockItem, stock_location_id: user.supplier.stock_locations.pluck(:id)
-        can [:admin, :create], Spree::StockLocation
-        cannot :read, Spree::StockLocation
-        can [:read, :manage], Spree::StockLocation, supplier_id: user.supplier_id
-        can [:admin, :manage], Spree::StockMovement, stock_item: { stock_location_id: user.supplier.stock_locations.pluck(:id) }
-        can :create, Spree::StockMovement
-        can [:admin, :update], Spree::Supplier, id: user.supplier_id
+      if user.supplier_admin?
+        can [:admin, :create, :read, :update, :destroy, :stock], Spree::Product, id: user.supplier.products.pluck(:id)
+        can [:admin, :create, :read, :update, :destroy],         Spree::Variant, id: user.supplier.variants.pluck(:id)
+
+        can [:admin, :read], Spree::Shipment, order: { state: 'complete' }, stock_location: { supplier_id: user.supplier_id }
+
+        #FIXME: come back to these when we work on shipping-related issues
+        # can [:admin, :manage, :read, :ready, :ship], Spree::Shipment, order: { state: 'complete' }, stock_location: { supplier_id: user.supplier_id }
+        # can [:admin, :create, :update], :stock_items
+        can [:admin, :manage, :create], Spree::StockItem,     stock_location_id: user.supplier.stock_locations.pluck(:id)
+        can [:admin, :manage, :create], Spree::StockLocation, supplier_id: user.supplier_id
+        can [:admin, :manage, :create], Spree::StockMovement, stock_item: { stock_location_id: user.supplier.stock_locations.pluck(:id) }
+
+        # cannot :read, Spree::StockLocation
+        # can [:read, :manage], Spree::StockLocation, supplier_id: user.supplier_id
+        can [:admin, :update],          Spree::Supplier, id: user.supplier_id
+        can [:admin, :read],            Spree::Order,    stock_location: { supplier_id: user.supplier_id }
       end
 
     end

--- a/app/models/spree/user_decorator.rb
+++ b/app/models/spree/user_decorator.rb
@@ -9,11 +9,11 @@ Spree.user_class.class_eval do
   end
 
   def supplier_admin?
-    supplier? && has_admin_role?
+    spree_roles.map(&:name).include?("supplier_admin")
   end
 
   def market_maker?
-    !supplier? && has_admin_role?
+    has_admin_role?
   end
 
   def has_admin_role?

--- a/app/views/spree/admin/products/_form.html.erb
+++ b/app/views/spree/admin/products/_form.html.erb
@@ -1,0 +1,198 @@
+<div data-hook="admin_product_form_fields">
+
+  <div class="row">
+
+    <div class="left col-9" data-hook="admin_product_form_left">
+      <div data-hook="admin_product_form_name">
+        <%= f.field_container :name do %>
+          <%= f.label :name, class: 'required' %>
+          <%= f.text_field :name, class: 'fullwidth title', required: true %>
+          <%= f.error_message_on :name %>
+        <% end %>
+      </div>
+
+      <div data-hook="admin_product_form_slug">
+        <%= f.field_container :slug do %>
+          <%= f.label :slug, class: 'required' %>
+          <%= f.text_field :slug, class: 'fullwidth title', required: true %>
+          <%= f.error_message_on :slug %>
+        <% end %>
+      </div>
+
+      <div data-hook="admin_product_form_description">
+        <%= f.field_container :description do %>
+          <%= f.label :description %>
+          <%= f.text_area :description, {rows: "#{unless @product.has_variants? then '22' else '15' end}", class: 'fullwidth'} %>
+          <%= f.error_message_on :description %>
+        <% end %>
+      </div>
+    </div>
+
+    <div class="right col-3" data-hook="admin_product_form_right">
+      <div data-hook="admin_product_form_price">
+        <%= f.field_container :price do %>
+          <%= f.label :price, class: 'required' %>
+          <%= render "spree/admin/shared/number_with_currency", f: f, amount_attr: :price,
+                     currency: Spree::Config.default_pricing_options.currency %>
+          <%= f.error_message_on :price %>
+        <% end %>
+      </div>
+
+      <% if show_rebuild_vat_checkbox? %>
+        <%= render "spree/admin/shared/rebuild_vat_prices_checkbox", form: f, model_name: "product" %>
+        <div class="clearfix"></div>
+      <% end %>
+
+      <div class="row">
+
+        <div data-hook="admin_product_form_cost_price" class="col-12">
+          <%= f.field_container :cost_price do %>
+            <%= f.label :cost_price %>
+
+            <%= render "spree/admin/shared/number_with_currency", f: f, amount_attr: :cost_price, currency_attr: :cost_currency %>
+
+            <%= f.error_message_on :cost_price %>
+            <%= f.error_message_on :cost_currency %>
+          <% end %>
+        </div>
+      </div>
+
+      <div class="clear"></div>
+
+      <div data-hook="admin_product_form_available_on">
+        <%= f.field_container :available_on do %>
+          <%= f.label :available_on %>
+          <%= f.error_message_on :available_on %>
+          <%= f.text_field :available_on, value: datepicker_field_value(@product.available_on), class: 'datepicker' %>
+        <% end %>
+      </div>
+
+      <div data-hook="admin_product_form_promotionable">
+        <%= f.field_container :promotionable do %>
+          <%= f.label :promotionable do %>
+            <%= f.check_box :promotionable %> <%= Spree::Product.human_attribute_name(:promotionable) %>
+          <% end %>
+          <%= f.field_hint :promotionable %>
+        <% end %>
+      </div>
+
+      <% if @product.has_variants? %>
+        <div data-hook="admin_product_form_multiple_variants">
+          <%= f.label :skus, Spree.t(:skus) %>
+          <span class="info">
+            <%= Spree.t(:info_product_has_multiple_skus, count: @product.variants.count) %>
+            <ul class="text_list">
+              <% @product.variants.first(5).each do |variant| %>
+                <li><%= link_to variant.sku, spree.edit_admin_product_variant_path(@product, variant) %></li>
+              <% end %>
+            </ul>
+            <% if @product.variants.count > 5 %>
+              <%= Spree.t(:info_number_of_skus_not_shown, count: @product.variants.count - 5) %>
+            <% end %>
+          </span>
+          <div class="info-actions">
+            <% if can?(:admin, Spree::Variant) %>
+              <%= link_to_with_icon 'th-large', Spree.t(:manage_variants), admin_product_variants_url(@product) %>
+            <% end %>
+          </div>
+        </div>
+      <% else %>
+        <div data-hook="admin_product_form_sku">
+          <%= f.field_container :sku do %>
+            <%= f.label :sku, Spree::Variant.human_attribute_name(:sku) %>
+            <%= f.text_field :sku, size: 16 %>
+          <% end %>
+        </div>
+
+        <div id="shipping_specs" class="row">
+          <% [:height, :width, :depth, :weight].each_with_index do |field, index| %>
+            <div id="shipping_specs_<%= field %>_field" class="col-6">
+              <div class="field">
+                <%= f.label field %>
+                <%= f.text_field field, value: number_with_precision(@product.send(field), precision: 2) %>
+              </div>
+            </div>
+          <% end %>
+        </div>
+
+      <% end %>
+
+      <div data-hook="admin_product_form_shipping_categories">
+        <%= f.field_container :shipping_categories do %>
+          <%= f.label :shipping_category_id, Spree::ShippingCategory.model_name.human %>
+          <%= f.field_hint :shipping_category %>
+          <%= f.collection_select(:shipping_category_id, @shipping_categories, :id, :name, { include_blank: Spree.t('match_choices.none') }, { class: 'custom-select' }) %>
+          <%= f.error_message_on :shipping_category %>
+        <% end %>
+      </div>
+
+      <div data-hook="admin_product_form_tax_category">
+        <%= f.field_container :tax_category do %>
+          <%= f.label :tax_category_id, Spree::TaxCategory.model_name.human %>
+          <%= f.field_hint :tax_category %>
+          <%= f.collection_select(:tax_category_id, @tax_categories, :id, :name, { include_blank: Spree.t('match_choices.none') }, { class: 'custom-select' }) %>
+          <%= f.error_message_on :tax_category %>
+        <% end %>
+      </div>
+    </div>
+
+  </div>
+
+  <div class="row">
+
+    <div class="col-9">
+      <% if try_spree_current_user.market_maker? %>
+        <div data-hook="admin_product_form_suppliers">
+          <%= f.field_container :suppliers do %>
+            <%= f.label :supplier_ids, plural_resource_name(Spree::Supplier) %><br />
+            <%= f.hidden_field :supplier_ids, value: @product.supplier_ids.join(',') %>
+          <% end %>
+        </div>
+      <% end %>
+
+      <div data-hook="admin_product_form_taxons">
+        <%= f.field_container :taxons do %>
+          <%= f.label :taxon_ids, plural_resource_name(Spree::Taxon) %><br />
+          <%= f.hidden_field :taxon_ids, value: @product.taxon_ids.join(',') %>
+        <% end %>
+      </div>
+
+      <div data-hook="admin_product_form_option_types">
+        <%= f.field_container :option_types do %>
+          <%= f.label :option_type_ids, plural_resource_name(Spree::OptionType) %>
+          <%= f.hidden_field :option_type_ids, value: @product.option_type_ids.join(',') %>
+        <% end %>
+      </div>
+
+      <div data-hook="admin_product_form_meta">
+        <div data-hook="admin_product_form_meta_title">
+          <%= f.field_container :meta_title do %>
+            <%= f.label :meta_title %>
+            <%= f.text_field :meta_title, class: 'fullwidth' %>
+          <% end %>
+        </div>
+
+        <div data-hook="admin_product_form_meta_keywords">
+          <%= f.field_container :meta_keywords do %>
+            <%= f.label :meta_keywords %>
+            <%= f.text_field :meta_keywords, class: 'fullwidth' %>
+          <% end %>
+        </div>
+
+        <div data-hook="admin_product_form_meta_description">
+          <%= f.field_container :meta_description do %>
+            <%= f.label :meta_description %>
+            <%= f.text_field :meta_description, class: 'fullwidth' %>
+          <% end %>
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+  <div class="clear"></div>
+
+  <div data-hook="admin_product_form_additional_fields"></div>
+
+  <div class="clear"></div>
+</div>

--- a/app/views/spree/api/shared/_pagination.json.jbuilder
+++ b/app/views/spree/api/shared/_pagination.json.jbuilder
@@ -1,0 +1,5 @@
+json.count        pagination.count
+json.total_count  pagination.total_count
+json.current_page pagination.current_page
+json.pages        pagination.total_pages
+json.per_page     pagination.limit_value

--- a/app/views/spree/api/suppliers/_supplier.json.jbuilder
+++ b/app/views/spree/api/suppliers/_supplier.json.jbuilder
@@ -1,0 +1,1 @@
+json.(supplier, *supplier_attributes)

--- a/app/views/spree/api/suppliers/index.json.jbuilder
+++ b/app/views/spree/api/suppliers/index.json.jbuilder
@@ -1,0 +1,4 @@
+json.suppliers(@suppliers) do |supplier|
+  json.partial!("spree/api/suppliers/supplier", supplier: supplier)
+end
+json.partial! 'spree/api/shared/pagination', pagination: @suppliers

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -92,6 +92,7 @@ en:
         subject: 'Thank you for signing up.  Please verify your information.'
         thank_you_again: "Thank you again for your business, <b>%{name}</b>"
         thank_you_for_signing_up: Thank you for signing up to be a drop ship supplier.
+    supplier_placeholder: Add a Supplier
     supplier_registration:
       already_signed_up: "You've already signed up to become a supplier."
       create:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,4 +6,8 @@ Spree::Core::Engine.routes.draw do
     resources :suppliers
   end
 
+  namespace :api do
+    resources :suppliers, only: :index
+  end
+
 end

--- a/db/default/spree/marketplace_roles.rb
+++ b/db/default/spree/marketplace_roles.rb
@@ -1,0 +1,1 @@
+Spree::Role.where(name: "supplier_admin").first_or_create

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,0 +1,8 @@
+# Loads seed data out of default dir
+default_path = File.join(File.dirname(__FILE__), 'default')
+%w(
+  marketplace_roles
+).each do |seed|
+  puts "Loading seed file: #{seed}"
+  require_relative "default/spree/#{seed}"
+end

--- a/lib/generators/solidus_marketplace/install/install_generator.rb
+++ b/lib/generators/solidus_marketplace/install/install_generator.rb
@@ -13,12 +13,18 @@ module SolidusMarketplace
         inject_into_file 'vendor/assets/stylesheets/spree/backend/all.css', " *= require spree/backend/solidus_marketplace\n", :before => /\*\//, :verbose => true
       end
 
+      def include_seed_data
+        seed_file = "db/seeds.rb"
+        content = "SolidusMarketplace::Engine.load_seed if defined?(SolidusMarketplace)"
+        append_file(seed_file, content) unless File.readlines(seed_file).last == content
+      end
+
       def add_migrations
         run 'bundle exec rake railties:install:migrations FROM=solidus_marketplace'
       end
 
       def run_migrations
-        run_migrations = options[:auto_run_migrations] || ['', 'y', 'Y'].include?(ask 'Would you like to run the migrations now? [Y/n]')
+        run_migrations = options[:auto_run_migrations] || ENV['AUTO_RUN_MIGRATIONS'] || ['', 'y', 'Y'].include?(ask 'Would you like to run the migrations now? [Y/n]')
         if run_migrations
           run 'bundle exec rake db:migrate'
         else

--- a/lib/solidus_marketplace/factories.rb
+++ b/lib/solidus_marketplace/factories.rb
@@ -84,6 +84,18 @@ FactoryGirl.define do
     supplier
   end
 
+  factory :supplier_admin_role, parent: :role do
+    name "supplier_admin"
+  end
+
+  factory :supplier_admin, parent: :user do
+    supplier
+
+    after :create do |user|
+      user.spree_roles << create(:supplier_admin_role)
+    end
+  end
+
   factory :variant_with_supplier, parent: :variant do
     after :create do |variant|
       variant.product.add_supplier! create(:supplier)

--- a/lib/spree/permitted_attributes_decorator.rb
+++ b/lib/spree/permitted_attributes_decorator.rb
@@ -1,0 +1,17 @@
+Spree::PermittedAttributes.class_eval do
+  @@supplier_attributes = [
+    :id,
+    :address_id,
+    :commission_flat_rate,
+    :commission_percentage,
+    :email,
+    :name,
+    :url,
+    :deleted_at,
+    :tax_id,
+    :token,
+    :slug
+  ]
+
+  mattr_reader(:supplier_attributes)
+end

--- a/spec/features/admin/stock_spec.rb
+++ b/spec/features/admin/stock_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 feature 'Admin - Product Stock Management', js: true do
 
   before do
-    @user = create(:supplier_user)
+    @user = create(:supplier_admin)
     @supplier1 = @user.supplier
     @supplier2 = create(:supplier)
     @product = create :product
@@ -42,7 +42,7 @@ feature 'Admin - Product Stock Management', js: true do
       end
     end
 
-    scenario "can create a new stock location" do
+    xscenario "can create a new stock location" do
       visit spree.new_admin_stock_location_path
       fill_in "Name", with: "London"
       check "Active"

--- a/spec/features/admin/suppliers_spec.rb
+++ b/spec/features/admin/suppliers_spec.rb
@@ -8,7 +8,7 @@ feature 'Admin - Suppliers', js: true do
     @supplier = create :supplier
   end
 
-  context 'as an Admin' do
+  context 'as an MarketMaker (aka admin)' do
 
     before do
       login_user create(:admin_user)
@@ -16,7 +16,7 @@ feature 'Admin - Suppliers', js: true do
       within '[data-hook=admin_tabs]' do
         click_link 'Suppliers'
       end
-      expect(page).to have_content('Listing Suppliers')
+      expect(page).to have_content('Suppliers')
     end
 
     xscenario 'should be able to create new supplier' do
@@ -32,7 +32,7 @@ feature 'Admin - Suppliers', js: true do
       fill_in 'supplier[address_attributes][address1]', with: '1 Test Drive'
       fill_in 'supplier[address_attributes][city]', with: 'Test City'
       fill_in 'supplier[address_attributes][zipcode]', with: '55555'
-      select2 'United States', from: 'Country'
+      select2 'United States of America', from: 'Country'
       select2 'Vermont', from: 'State'
       fill_in 'supplier[address_attributes][phone]', with: '555-555-5555'
       click_button 'Create'
@@ -71,20 +71,24 @@ feature 'Admin - Suppliers', js: true do
 
   context 'as a Supplier' do
     before do
-      @user = create(:supplier_user)
+      @user = create(:supplier_admin)
       login_user @user
       visit spree.edit_admin_supplier_path(@user.supplier)
     end
 
     scenario 'should only see tabs they have access to' do
       within '[data-hook=admin_tabs]' do
-        expect(page).to_not have_link('Overview')
         expect(page).to have_link('Products')
+        expect(page).to have_link('Stock')
+        expect(page).to have_link('Stock Locations')
+        expect(page).to have_link('Profile')
+        expect(page).to have_link('Orders')
+
+        expect(page).to_not have_link('Overview')
         expect(page).to_not have_link('Reports')
         expect(page).to_not have_link('Configuration')
         expect(page).to_not have_link('Promotions')
         expect(page).to_not have_link('Suppliers')
-        expect(page).to have_link('Shipments')
       end
     end
 

--- a/spec/models/spree/product_decorator_spec.rb
+++ b/spec/models/spree/product_decorator_spec.rb
@@ -3,11 +3,54 @@ require 'spec_helper'
 describe Spree::Product do
 
   let(:product) { create :product }
+  let(:supplier1) { create(:supplier) }
+  let(:supplier2) { create(:supplier) }
 
-  it '#supplier?' do
-    expect(product.supplier?).to eq false
-    product.add_supplier! create(:supplier)
-    expect(product.reload.supplier?).to eq true
+  describe "#add_supplier!" do
+    context "when passed a supplier" do
+      it "adds the supplier to product's list of supppliers" do
+        expect(product.suppliers).to be_empty
+        product.add_supplier!(supplier1)
+        expect(product.reload.suppliers).to include(supplier1)
+      end
+    end
+
+    context "when passed a supplier_id" do
+      it "adds the supplier to product's list of supppliers" do
+        expect(product.suppliers).to be_empty
+        product.add_supplier!(supplier2.id)
+        expect(product.reload.suppliers).to include(supplier2)
+      end
+    end
   end
+
+  describe "#add_suppliers!" do
+    it "adds multiple suppliers to the product's list of suppliers" do
+      expect(product.suppliers).to be_empty
+      product.add_suppliers!([supplier1.id, supplier2.id])
+      expect(product.reload.suppliers).to include(supplier1)
+      expect(product.reload.suppliers).to include(supplier2)
+    end
+  end
+
+  describe "#remove_suppliers!" do
+    it "removes multiple suppliers from the product's list of suppliers" do
+      product.add_suppliers!([supplier1.id, supplier2.id])
+      expect(product.reload.suppliers).to include(supplier1)
+      expect(product.reload.suppliers).to include(supplier2)
+
+      product.remove_suppliers!([supplier1.id, supplier2.id])
+      expect(product.suppliers).to be_empty
+    end
+  end
+
+  describe '#supplier?' do
+    it "returns true if one or more suppliers are present" do
+      expect(product.supplier?).to eq false
+      product.add_supplier! create(:supplier)
+      expect(product.reload.supplier?).to eq true
+    end
+  end
+
 
 end

--- a/spec/models/spree/stock/splitter/drop_ship_spec.rb
+++ b/spec/models/spree/stock/splitter/drop_ship_spec.rb
@@ -38,7 +38,7 @@ module Spree
 
         let(:packer) { build(:stock_packer) }
 
-        subject { DropShip.new(packer) }
+        subject { DropShip.new(packer.stock_location) }
 
         it 'splits packages for drop ship' do
           package = Package.new(packer.stock_location)

--- a/spec/models/spree/supplier_ability_spec.rb
+++ b/spec/models/spree/supplier_ability_spec.rb
@@ -4,9 +4,15 @@ require 'spree/testing_support/ability_helpers'
 
 describe Spree::SupplierAbility do
 
-  let(:user) { create(:user, supplier: create(:supplier)) }
+  let(:supplier) { create(:supplier) }
+  let(:supplier_admin_role) { build :role, name: "supplier_admin" }
+  let(:user) { create(:user, supplier: supplier) }
   let(:ability) { Spree::SupplierAbility.new(user) }
   let(:token) { nil }
+
+  before(:each) do
+    user.spree_roles << supplier_admin_role
+  end
 
   context 'for Dash' do
     let(:resource) { Spree::Admin::RootController }
@@ -21,17 +27,20 @@ describe Spree::SupplierAbility do
   context 'for Product' do
     let(:resource) { create(:product) }
 
-    #TODO: pending - needs to be uncommented and fixed
-    # it_should_behave_like 'index allowed'
-    # it_should_behave_like 'admin granted'
+    before(:each) do
+      resource.add_supplier!(user.supplier)
+    end
+
+    it_should_behave_like 'index allowed'
+    it_should_behave_like 'admin granted'
 
     context 'requested by another suppliers user' do
-      let(:resource) {
+      let(:other_resource) {
         product = create(:product)
         product.add_supplier!(create(:supplier))
         product
       }
-      it { expect(ability).to_not be_able_to :read, resource }
+      it { expect(ability).to_not be_able_to :read, other_resource }
     end
 
     context 'requested by suppliers user' do
@@ -63,11 +72,9 @@ describe Spree::SupplierAbility do
           order.stock_locations.first.update_attribute :supplier, user.supplier
           Spree::Shipment.new({order: order, stock_location: order.stock_locations.first })
         }
-        it_should_behave_like 'access granted'
+        it_should_behave_like 'read only'
         it_should_behave_like 'index allowed'
         it_should_behave_like 'admin granted'
-        it { expect(ability).to be_able_to :ready, resource }
-        it { expect(ability).to be_able_to :ship, resource }
       end
 
       context 'when order is incomplete' do
@@ -113,7 +120,7 @@ describe Spree::SupplierAbility do
         variant.product.add_supplier! supplier
         supplier.stock_locations.first
       }
-      it_should_behave_like 'create only'
+      it_should_behave_like 'access denied'
     end
 
     context 'requested by suppliers user' do
@@ -141,7 +148,7 @@ describe Spree::SupplierAbility do
         variant.product.add_supplier! supplier
         Spree::StockMovement.new({ stock_item: supplier.stock_locations.first.stock_items.first })
       }
-      it_should_behave_like 'create only'
+      it_should_behave_like 'admin denied'
     end
 
     context 'requested by suppliers user' do

--- a/spec/models/spree/user_decorator_spec.rb
+++ b/spec/models/spree/user_decorator_spec.rb
@@ -8,6 +8,7 @@ describe Spree.user_class do
 
   let(:user) { build :user }
   let(:admin_role) { build :admin_role }
+  let(:supplier_admin_role) { build :role, name: "supplier_admin" }
 
   describe '#supplier?' do
     it "returns true if user is a supplier" do
@@ -21,57 +22,24 @@ describe Spree.user_class do
   end
 
   describe '#supplier_admin?' do
-    context "when user is a supplier" do
-      before(:each) do
-        user.supplier = build :supplier
-      end
-
-      it "returns true if user has admin role" do
-        user.spree_roles << admin_role
-        expect(user.supplier_admin?).to eq true
-      end
-
-      it "returns false if user doesn't have an admin role" do
-        expect(user.supplier_admin?).to eq false
-      end
+    it "returns true if user has supplier admin role" do
+      user.spree_roles << supplier_admin_role
+      expect(user.supplier_admin?).to eq true
     end
 
-    context "when user is not a supplier" do
-      it "returns false if user has admin role" do
-        user.spree_roles << admin_role
-        expect(user.supplier_admin?).to eq false
-      end
-
-      it "returns false if user doesn't have admin role" do
-        expect(user.supplier_admin?).to eq false
-      end
+    it "returns false if user doesn't have a supplier admin role" do
+      expect(user.supplier_admin?).to eq false
     end
   end
 
   describe '#market_maker?' do
-    context "when user is a supplier" do
-      it "returns false if user has an admin role" do
-        user.spree_roles << admin_role
-        user.supplier = build :supplier
-        expect(user.market_maker?).to eq false
-      end
-
-      it "returns false if user doesn't have an admin role" do
-        user.supplier = build :supplier
-        expect(user.market_maker?).to eq false
-      end
+    it "returns true if user has an admin role" do
+      user.spree_roles << admin_role
+      expect(user.market_maker?).to eq true
     end
 
-    context "when user is not a supplier" do
-      it "returns true if user has admin role" do
-        user.spree_roles << admin_role
-
-        expect(user.market_maker?).to eq true
-      end
-
-      it "returns false if user doesn't have an admin role" do
-        expect(user.market_maker?).to eq false
-      end
+    it "returns false if user doesn't have an admin role" do
+      expect(user.market_maker?).to eq false
     end
   end
 


### PR DESCRIPTION
This should take care of issues #20 and #21.

End results is that, as of this PR, 
* a MarketMaker can edit a product and map it to one or more suppliers
* when a supplier logs in, they only see their products
* MarketMakers still see all products
* MarketMakers can add/remove one or many suppliers to/from a product, then update the product to save those changes

Implemented and lightly tested in the browser, but needs specs updated. 

Pushing PR now to get some early eyes on it, but still need to work on those specs.