### PR TITLE
Fix removing suppliers when updating product properties

### DIFF
--- a/app/controllers/spree/admin/products_controller_decorator.rb
+++ b/app/controllers/spree/admin/products_controller_decorator.rb
@@ -2,7 +2,7 @@ Spree::Admin::ProductsController.class_eval do
 
   before_action :get_suppliers,            only: [:edit] #, :update]
   before_action :supplier_collection,      only: [:index]
-  after_action  :update_product_suppliers, only: [:update]
+  after_action  :update_product_suppliers, only: [:update], unless: -> { params['product']['supplier_ids'].nil? }
   create.after  :add_product_to_supplier
 
   private


### PR DESCRIPTION
As originally written, if you were on a page such as "Product Properties", the fact that supplier_ids weren't passed in to the controller would cause all existing suppliers to get removed from that product.  The fix is to only go through the logic of fixing up suppliers if the supplier_ids key is present.